### PR TITLE
Specify dist output location for Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-island-004ed0000.yml
+++ b/.github/workflows/azure-static-web-apps-mango-island-004ed0000.yml
@@ -42,7 +42,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
-          output_location: "" # Built app content directory - optional
+          output_location: "dist" # Built app content directory - optional
           github_id_token: ${{ steps.idtoken.outputs.result }}
           ###### End of Repository/Build Configurations ######
 


### PR DESCRIPTION
## Summary
- provide `dist` as Azure Static Web Apps output folder so the build artifacts are detected

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a7d46b4832ba660dcf2f9ecb102